### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,5 +1,8 @@
 name: PR Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish to PyPI
 on: 
   release:
     types: [published]
+permissions:
+  contents: read
 jobs:
   pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BAMANEE/SwimrankingsScraper/security/code-scanning/2](https://github.com/BAMANEE/SwimrankingsScraper/security/code-scanning/2)

In general, the fix is to explicitly declare restricted `GITHUB_TOKEN` permissions for this workflow, either at the top level (applying to all jobs) or within the specific job. Since this workflow’s single job only needs to check out code and run tests, it only requires read access to repository contents; it does not need to write to issues, pull requests, or repository contents.

The best fix without changing existing functionality is to add a `permissions` block at the root level of `.github/workflows/pr-tests.yml`, right under the `name:` line and before the `on:` block. Set `contents: read` as a minimal safe default. No additional imports or methods are needed; this is just a YAML configuration change.

Concretely:
- Edit `.github/workflows/pr-tests.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: PR Tests`). This will apply to all jobs (currently just `test`) and constrain the `GITHUB_TOKEN` accordingly, satisfying CodeQL’s recommendation and documenting the workflow’s permission needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
